### PR TITLE
Adds optional specification of node name to slave file

### DIFF
--- a/pregelix-dist/src/main/resources/scripts/startAllNCs.sh
+++ b/pregelix-dist/src/main/resources/scripts/startAllNCs.sh
@@ -34,5 +34,10 @@ PREGELIX_PATH=`pwd`
 
 for i in `cat conf/slaves`
 do
-   ssh $i "cd ${PREGELIX_PATH}; export JAVA_HOME=${JAVA_HOME}; bin/startnc.sh"
+   if [[ $i == *","* ]]; then
+      arrIN=(${i//,/ })
+      ssh ${arrIN[0]} "cd ${PREGELIX_PATH}; export JAVA_HOME=${JAVA_HOME}; bin/startnc.sh ${arrIN[1]}"
+   else
+      ssh $i "cd ${PREGELIX_PATH}; export JAVA_HOME=${JAVA_HOME}; bin/startnc.sh"
+   fi
 done

--- a/pregelix-dist/src/main/resources/scripts/startnc.sh
+++ b/pregelix-dist/src/main/resources/scripts/startnc.sh
@@ -66,7 +66,11 @@ IPADDR=`bin/getip.sh`
 #echo $IPADDR
 
 #Get node ID
-NODEID=`hostname | cut -d '.' -f 1`
+if [ $# -eq 0 ]; then
+   NODEID=`hostname | cut -d '.' -f 1`
+else
+   NODEID=$1
+fi
 
 PREGELIX_HOME=`pwd`
 

--- a/pregelix-dist/src/main/resources/scripts/stopAllNCs.sh
+++ b/pregelix-dist/src/main/resources/scripts/stopAllNCs.sh
@@ -34,5 +34,10 @@ PREGELIX_PATH=`pwd`
 
 for i in `cat conf/slaves`
 do
-   ssh $i "cd ${PREGELIX_PATH}; bin/stopnc.sh"
+   if [[ $i == *","* ]]; then
+      arrIN=(${i//,/ })
+      ssh ${arrIN[0]} "cd ${PREGELIX_PATH}; bin/stopnc.sh"
+   else
+      ssh $i "cd ${PREGELIX_PATH}; bin/stopnc.sh"
+   fi
 done


### PR DESCRIPTION
This enables to specify the slave nodes like this to pass an own name for the hyracks node controllers.
localhost,nc1
localhost,nc2

The old way remains working. This change enables to run multiple node controllers on one machine and it makes the intergration with Asterix and its testing easier.
